### PR TITLE
Vagrant pour tests en local, optimisation du déploiement, support de npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Déploiement afup
+
+## Travail avec un environnement local
+Nécessite vagrant.
+
+Pour tester le déploiement du repo web (par exemple):
+
+1. Démarrer la vagrant: `vagrant up`
+2. S'y connecter: `vagrant ssh`
+3. Changer pour l'utilisateur "afup": `sudo su afup`
+4. Créer les fichiers de configuration dans /home/afup/afup.org/shared:
+  - app/config/parameters.yml
+  - configs/application/config.php
+5. Créer le fichier de configuration wordpress dans /home/afup/event.afup.org/web: wp-config.php
+6. Jouer le playbook: `ansible-playbook /vagrant/playbooks/web.yml`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,47 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/jessie64"
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    
+    echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" > /etc/apt/sources.list.d/ansible.list
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
+    apt-get update
+    apt-get install -y ansible
+    export PYTHONUNBUFFERED=1
+    export ANSIBLE_FORCE_COLOR=1
+    cd /vagrant/
+    export ANSIBLE_CONFIG=/vagrant/vagrant/ansible.cfg
+    ansible-playbook /vagrant/playbooks/server.yml
+  SHELL
+end

--- a/playbooks/server.yml
+++ b/playbooks/server.yml
@@ -1,16 +1,13 @@
 - 
   hosts: 127.0.0.1
-  gather_facts: no
-  tasks:
-    - apt_key:
-        url: https://dl.yarnpkg.com/debian/pubkey.gpg
-        state: present
-
-    - apt_repository:
-        repo: deb https://dl.yarnpkg.com/debian/ stable main
-        state: present
-        filename: yarn
-
-    - apt:
-        name: yarn
-        state: present
+  vars_files:
+    - ../vars/static.yml
+  roles: 
+    - php
+    - git
+    - afup
+    - nodejs
+    - yarn
+    # mysql
+    # apache
+    # nginx

--- a/playbooks/server.yml
+++ b/playbooks/server.yml
@@ -1,0 +1,16 @@
+- 
+  hosts: 127.0.0.1
+  gather_facts: no
+  tasks:
+    - apt_key:
+        url: https://dl.yarnpkg.com/debian/pubkey.gpg
+        state: present
+
+    - apt_repository:
+        repo: deb https://dl.yarnpkg.com/debian/ stable main
+        state: present
+        filename: yarn
+
+    - apt:
+        name: yarn
+        state: present

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -40,12 +40,6 @@
         path: "{{ custom_shared_dir }}/{{ cache_dir }}/composer.phar"
         state: absent
 
-    - synchronize:
-        src: "{{ custom_shared_dir }}/{{ cache_dir }}"
-        dest: "{{ deploy_helper.new_release_path }}"
-        rsync_opts:
-          - "--exclude=.git"
-
     - apt_key:
         url: https://dl.yarnpkg.com/debian/pubkey.gpg
         state: present
@@ -67,6 +61,12 @@
       args:
         chdir: "{{ deploy_helper.new_release_path }}"
       when: packages.stat.exists
+
+    - synchronize:
+        src: "{{ custom_shared_dir }}/{{ cache_dir }}"
+        dest: "{{ deploy_helper.new_release_path }}"
+        rsync_opts:
+          - "--exclude=.git"
     
     - file:
         path: "{{deploy_helper.new_release_path }}/{{ item }}"

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -66,12 +66,12 @@
         state: absent
 
     - stat:
-        path: "{{ custom_shared_dir }}/{{ cache_dir }}/package.json"
+        path: "{{ custom_shared_dir }}/{{ cache_dir }}/htdocs/package.json"
       register: packages
 
     - shell: "yarn install --prod --non-interactive"
       args:
-        chdir: "{{ custom_shared_dir }}/{{ cache_dir }}"
+        chdir: "{{ custom_shared_dir }}/{{ cache_dir }}/htdocs"
       when: packages.stat.exists
 
     - synchronize:

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -4,7 +4,7 @@
   vars:
     deploy_repository: "http://github.com/afup/web.git"
     deploy_path: "/home/sources/web"
-    deploy_branch: "fix/lazy-connect"
+    deploy_branch: "master"
     custom_shared_dir: "/home/afup/afup.org/shared"
     event_custom_shared_dir: "/home/afup/event.afup.org/web"
     cache_dir: "cache"

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -7,37 +7,67 @@
     deploy_branch: "master"
     custom_shared_dir: "/home/afup/afup.org/shared"
     event_custom_shared_dir: "/home/afup/event.afup.org/web"
+    cache_dir: "cache"
   tasks:
     - deploy_helper:
         path: "{{ deploy_path }}"
     - git:
         repo: "{{ deploy_repository }}"
-        dest: "{{ deploy_helper.new_release_path }}"
+        dest: "{{ custom_shared_dir }}/{{ cache_dir }}"
         accept_hostkey: True
         version: "{{ deploy_branch }}"
         depth: 1
+        force: yes
       register: git_clone_result
     - get_url:
         url: https://getcomposer.org/installer
-        dest: "{{ deploy_helper.new_release_path }}/composer_installer"
-    - shell: "cat {{ deploy_helper.new_release_path }}/composer_installer | php -- --install-dir={{ deploy_helper.new_release_path }}"
+        dest: "{{ custom_shared_dir }}/{{ cache_dir }}/composer_installer"
+    - shell: "cat {{ custom_shared_dir }}/{{ cache_dir }}/composer_installer | php -- --install-dir={{ custom_shared_dir }}/{{ cache_dir }}"
       environment:
         COMPOSER_HOME: "/tmp/tmp_composer_home_deploy"
     - shell: "php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction --working-dir={{ item }}"
       environment:
         COMPOSER_HOME: "/tmp/tmp_composer_home_deploy"
       args:
-        chdir: "{{ deploy_helper.new_release_path }}"
+        chdir: "{{ custom_shared_dir }}/{{ cache_dir }}"
       with_items:
-        - "{{ deploy_helper.new_release_path }}/event"
-        - "{{ deploy_helper.new_release_path }}"
+        - "{{ custom_shared_dir }}/{{ cache_dir }}/event"
+        - "{{ custom_shared_dir }}/{{ cache_dir }}"
     - file:
-        path: "{{ deploy_helper.new_release_path }}/composer_installer"
+        path: "{{ custom_shared_dir }}/{{ cache_dir }}/composer_installer"
         state: absent
     - file:
-        path: "{{ deploy_helper.new_release_path }}/composer.phar"
+        path: "{{ custom_shared_dir }}/{{ cache_dir }}/composer.phar"
         state: absent
 
+    - synchronize:
+        src: "{{ custom_shared_dir }}/{{ cache_dir }}"
+        dest: "{{ deploy_helper.new_release_path }}"
+        rsync_opts:
+          - "--exclude=.git"
+
+    - apt_key:
+        url: https://dl.yarnpkg.com/debian/pubkey.gpg
+        state: present
+
+    - apt_repository:
+        repo: deb https://dl.yarnpkg.com/debian/ stable main
+        state: present
+        filename: yarn
+
+    - apt:
+        name: yarn
+        state: present
+
+    - stat:
+        file: "{{ deploy_helper.new_release_path }}/package.json"
+        register: packages
+
+    - shell: "yarn install --prod --non-interactive"
+      args:
+        chdir: "{{ deploy_helper.new_release_path }}"
+      when: packages.stat.exists
+    
     - file:
         path: "{{deploy_helper.new_release_path }}/{{ item }}"
         state: absent

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -4,11 +4,14 @@
   vars:
     deploy_repository: "http://github.com/afup/web.git"
     deploy_path: "/home/sources/web"
-    deploy_branch: "master"
+    deploy_branch: "fix/lazy-connect"
     custom_shared_dir: "/home/afup/afup.org/shared"
     event_custom_shared_dir: "/home/afup/event.afup.org/web"
     cache_dir: "cache"
+    source_config: "/home/afup/afup.org/shared/configs/"
+    source_parameters: "/home/afup/afup.org/shared/configs/app/parameters.yml"
   tasks:
+    - include_vars: ../vars/static.yml
     - deploy_helper:
         path: "{{ deploy_path }}"
     - git:
@@ -19,15 +22,37 @@
         depth: 1
         force: yes
       register: git_clone_result
-    - get_url:
+
+    - file:
+        path: "{{ custom_shared_dir }}/{{ cache_dir }}/{{ item }}"
+        state: absent
+        force: yes
+      with_items:
+        - "{{ static_files }}"
+        - "{{ static_directories }}"
+    
+    - name: Link config files 
+      file:
+        path: "{{ custom_shared_dir }}/{{ cache_dir }}/{{ item }}"
+        src: "{{ custom_shared_dir }}/{{ item }}"
+        state: link
+        force: yes
+      with_items:
+        - "{{ static_files }}"
+        - "{{ static_directories }}"
+
+    - name: Download composer
+      get_url:
         url: https://getcomposer.org/installer
         dest: "{{ custom_shared_dir }}/{{ cache_dir }}/composer_installer"
     - shell: "cat {{ custom_shared_dir }}/{{ cache_dir }}/composer_installer | php -- --install-dir={{ custom_shared_dir }}/{{ cache_dir }}"
       environment:
         COMPOSER_HOME: "/tmp/tmp_composer_home_deploy"
-    - shell: "php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction --working-dir={{ item }}"
+    - name: Install composer dependencies
+      shell: "php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction --working-dir={{ item }}"
       environment:
         COMPOSER_HOME: "/tmp/tmp_composer_home_deploy"
+        SYMFONY_ENV: prod
       args:
         chdir: "{{ custom_shared_dir }}/{{ cache_dir }}"
       with_items:
@@ -41,16 +66,16 @@
         state: absent
 
     - stat:
-        file: "{{ deploy_helper.new_release_path }}/package.json"
-        register: packages
+        path: "{{ custom_shared_dir }}/{{ cache_dir }}/package.json"
+      register: packages
 
     - shell: "yarn install --prod --non-interactive"
       args:
-        chdir: "{{ deploy_helper.new_release_path }}"
+        chdir: "{{ custom_shared_dir }}/{{ cache_dir }}"
       when: packages.stat.exists
 
     - synchronize:
-        src: "{{ custom_shared_dir }}/{{ cache_dir }}"
+        src: "{{ custom_shared_dir }}/{{ cache_dir }}/"
         dest: "{{ deploy_helper.new_release_path }}"
         rsync_opts:
           - "--exclude=.git"
@@ -67,58 +92,13 @@
         - "event/wp/composer.json"
 
     - file:
-        path: "{{ deploy_helper.new_release_path }}/{{ item }}"
-        src: "{{ custom_shared_dir }}/{{ item }}"
+        path: "{{ deploy_helper.new_release_path }}/event/wp/{{ item }}"
+        src: "{{ event_custom_shared_dir }}/{{ item }}"
         state: link
       with_items:
-        - "htdocs/templates/forumphp2016/images/intervenants"
-        - "htdocs/templates/forumphp2005/talks"
-        - "htdocs/templates/forumphp2006/talks"
-        - "htdocs/templates/forumphp2007/talks"
-        - "htdocs/templates/forumphp2008/images/intervenants"
-        - "htdocs/templates/forumphp2009/images/intervenants"
-        - "htdocs/templates/forumphp2010/images/intervenants"
-        - "htdocs/templates/forumphp2012/images/intervenants"
-        - "htdocs/templates/forumphp2013/images/intervenants"
-        - "htdocs/templates/forumphp2014/images/intervenants"
-        - "htdocs/templates/forumphp2015/images/intervenants"
-        - "tmp"
-        - "cron/mailchimp.log"
-        - "cron/notifications_stats_ticket.log"
-        - "cron/reminder.log"
-        - "cron/twitterbot.log"
-        - "cron/explorePlanete.log"
-        - "cron/syncAfupRedmine.log"
-        - "cron/syncAfupSympa.log"
-        - "app/config/parameters.yml"
-        - "htdocs/templates/forumphp2008/resumes"
-        - "htdocs/templates/forumphp2009/resumes"
-        - "htdocs/templates/forumphp2012/resumes"
-        - "htdocs/templates/forumphp2013/resumes"
-        - "htdocs/templates/phptourclermont2016/images/intervenants"
-        - "htdocs/templates/phptourlille2011/images/intervenants"
-        - "htdocs/templates/phptourluxembourg2015/images/intervenants" 
-        - "htdocs/templates/phptourlyon2014/images/intervenants"
-        - "htdocs/templates/phptournantes2012/images/intervenants"
-        - "htdocs/templates/site/images"
-        - "htdocs/wiki/files"
-        - "htdocs/wiki/wakka.config.php"
-        - "htdocs/uploads"
-        - "configs/application/config.php"
-        - "htdocs/docs"
-        - "var/logs"
-
-    - file:
-        path: "{{ deploy_helper.new_release_path }}/event/wp/{{ item.target }}"
-        src: "{{ event_custom_shared_dir }}/{{ item.src }}"
-        state: link
-      with_items:
-        - src   : "wp-content/uploads"
-          target: "wp-content/uploads"
-        - src   : "wp-config.php"
-          target: "wp-config.php"
-
-
+        - "wp-content/uploads"
+        - "wp-config.php"
+          
     - deploy_helper:
         path: "{{ deploy_path }}"
         release: '{{ deploy_helper.new_release }}'

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -40,19 +40,6 @@
         path: "{{ custom_shared_dir }}/{{ cache_dir }}/composer.phar"
         state: absent
 
-    - apt_key:
-        url: https://dl.yarnpkg.com/debian/pubkey.gpg
-        state: present
-
-    - apt_repository:
-        repo: deb https://dl.yarnpkg.com/debian/ stable main
-        state: present
-        filename: yarn
-
-    - apt:
-        name: yarn
-        state: present
-
     - stat:
         file: "{{ deploy_helper.new_release_path }}/package.json"
         register: packages

--- a/roles/afup/files/sudoers.d/afup
+++ b/roles/afup/files/sudoers.d/afup
@@ -1,0 +1,1 @@
+afup ALL=(ALL) NOPASSWD: /usr/sbin/apache2ctl

--- a/roles/afup/tasks/main.yml
+++ b/roles/afup/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Create group
+  group:
+    name: afup
+    state: present
+
+- name: Create user
+  user:
+    name: afup
+    home: /home/afup
+    group: afup
+    groups: www-data
+    shell: /bin/bash
+
+- name:
+  copy:
+    src: "sudoers.d/afup"
+    dest: "/etc/sudoers.d/afup"
+    owner: root
+    group: root
+    mode: 0440
+
+- name: Create base folders
+  file:
+    path: "{{ item }}"
+    state: directory
+    recurse: yes
+    owner: www-data
+    group: www-data
+    mode: 0775
+  with_items:
+    - "/home/afup/afup.org"
+    - "/home/afup/afup.org/shared"
+    - "/home/afup/afup.org/web"
+    - "/home/sources/" # specify this folder to ensure owner & group at this level
+    - "/home/sources/web/releases"
+    - "/home/sources/web/shared"
+    - "/home/afup/event.afup.org"
+    - "/home/afup/event.afup.org/web"
+
+- name: Create project afup specifics folders
+  file:
+    path: "/home/afup/afup.org/shared/{{ item }}"
+    state: directory
+    recurse: yes
+    owner: www-data
+    group: www-data
+    mode: 0775
+  with_items:
+    - "{{ static_directories }}"
+
+- name: Create project event specifics folders
+  file:
+    path: "/home/afup/event.afup.org/web/{{ item }}"
+    state: directory
+    recurse: yes
+    owner: www-data
+    group: www-data
+    mode: 0775
+  with_items:
+    - "{{ event_static_directories }}"
+...

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Install git
+  apt:
+    name: git
+    state: present
+...

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+nodejs_version: 6.11.4
+...

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Unpack node archive
+  unarchive: src="http://nodejs.org/dist/v{{ nodejs_version }}/node-v{{ nodejs_version }}-linux-x64.tar.gz" dest="/usr/local" copy=no
+  environment:
+    LANG: C
+    LC_ALL: C
+    LC_MESSAGES: C
+
+- name: Create node directory symlink
+  file: src=/usr/local/node-v{{ nodejs_version }}-linux-x64 dest=/usr/local/node state=link
+
+- name: Create node binary symlink
+  file: src=/usr/local/node/bin/node dest=/usr/local/bin/node state=link
+
+- name: Create npm binary symlink
+  file: src=/usr/local/node/bin/npm dest=/usr/local/bin/npm state=link
+
+...

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Installation de PHP
+  apt:
+    name: php5
+    state: present
+
+- name: Installation des extensions
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - php5-curl
+    - php5-mysqlnd
+
+- name: Activation des extensions
+  shell: "php5enmod {{ item }}"
+  with_items:
+    - curl
+    - mysqli
+...

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Add yarn public key
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+
+- apt:
+    name: apt-transport-https
+    state: present
+
+- name: Add yarn repository 
+  apt_repository:
+    repo: deb https://dl.yarnpkg.com/debian/ stable main
+    state: present
+    filename: yarn
+    
+- name: Install yarn
+  apt:
+    name: yarn
+    state: present
+
+...

--- a/vagrant/ansible.cfg
+++ b/vagrant/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = /vagrant/roles

--- a/vars/static.yml
+++ b/vars/static.yml
@@ -1,0 +1,46 @@
+---
+
+static_files:
+  - "cron/mailchimp.log"
+  - "cron/notifications_stats_ticket.log"
+  - "cron/reminder.log"
+  - "cron/twitterbot.log"
+  - "cron/explorePlanete.log"
+  - "cron/syncAfupRedmine.log"
+  - "cron/syncAfupSympa.log"
+  - "app/config/parameters.yml"
+  - "htdocs/wiki/wakka.config.php"
+  - "configs/application/config.php"
+
+static_directories:
+  - "htdocs/templates/forumphp2016/images/intervenants"
+  - "htdocs/templates/forumphp2005/talks"
+  - "htdocs/templates/forumphp2006/talks"
+  - "htdocs/templates/forumphp2007/talks"
+  - "htdocs/templates/forumphp2008/images/intervenants"
+  - "htdocs/templates/forumphp2009/images/intervenants"
+  - "htdocs/templates/forumphp2010/images/intervenants"
+  - "htdocs/templates/forumphp2012/images/intervenants"
+  - "htdocs/templates/forumphp2013/images/intervenants"
+  - "htdocs/templates/forumphp2014/images/intervenants"
+  - "htdocs/templates/forumphp2015/images/intervenants"
+  - "tmp"
+  - "htdocs/templates/forumphp2008/resumes"
+  - "htdocs/templates/forumphp2009/resumes"
+  - "htdocs/templates/forumphp2012/resumes"
+  - "htdocs/templates/forumphp2013/resumes"
+  - "htdocs/templates/phptourclermont2016/images/intervenants"
+  - "htdocs/templates/phptourlille2011/images/intervenants"
+  - "htdocs/templates/phptourluxembourg2015/images/intervenants" 
+  - "htdocs/templates/phptourlyon2014/images/intervenants"
+  - "htdocs/templates/phptournantes2012/images/intervenants"
+  - "htdocs/templates/site/images"
+  - "htdocs/wiki/files"
+  - "htdocs/uploads"
+  - "htdocs/docs"
+  - "var/logs"
+
+event_static_directories:
+  - "wp-content/uploads"
+
+...


### PR DESCRIPTION
Ajout d'un répertoire de cache pour le repo git & d'un yarn install si on trouve un fichier package.json.

Le yarn install et le composer install sont effectués dans ce répertoire de cache, qui est ensuite synchronisé vers la destination, afin d'accélérer le déploiement (fix #1)