### PR TITLE
Modifier le déploiement du baromètre suite montée de version de sf

### DIFF
--- a/playbooks/barometre.yml
+++ b/playbooks/barometre.yml
@@ -8,10 +8,10 @@
     shared_files:
       - app/config/parameters.yml
     shared_dirs:
-      - app/logs
+      - var/logs
       - web/.well-known
     deploy_exclude_paths:
-      - app/logs
+      - var/logs
       - web/app_dev.php
       - .git
   tasks:
@@ -91,7 +91,7 @@
         chdir: "{{ deploy_helper.new_release_path }}"
 
     - name: "Running database migrations"
-      shell: php app/console doctrine:migrations:migrate --env=prod --no-interaction
+      shell: php bin/console doctrine:migrations:migrate --env=prod --no-interaction
       args:
         chdir: "{{ deploy_helper.new_release_path }}"
 

--- a/playbooks/barometre_preprod.yml
+++ b/playbooks/barometre_preprod.yml
@@ -8,10 +8,10 @@
     shared_files:
       - app/config/parameters.yml
     shared_dirs:
-      - app/logs
+      - var/logs
       - web/.well-known
     deploy_exclude_paths:
-      - app/logs
+      - var/logs
       - web/app_dev.php
       - .git
   tasks:
@@ -91,7 +91,7 @@
         chdir: "{{ deploy_helper.new_release_path }}"
 
     - name: "Running database migrations"
-      shell: php app/console doctrine:migrations:migrate --env=prod --no-interaction
+      shell: php bin/console doctrine:migrations:migrate --env=prod --no-interaction
       args:
         chdir: "{{ deploy_helper.new_release_path }}"
 


### PR DESCRIPTION
Une PR est présente sur le projet afup/barometre pour mettre à jour Symfony en version 3.4 : https://github.com/afup/barometre/pull/340

Lors de la montée de version, la structure des dossiers a changé ce qui implique une modification du déploiement.

