### PR TITLE
on corrige le déploiement suite à la suppression du fichier config.php

### DIFF
--- a/vars/static.yml
+++ b/vars/static.yml
@@ -12,7 +12,6 @@ static_files:
   - "cron/sync_techletter.log"
   - "app/config/parameters.yml"
   - "app/config/gestion-mailing-49e890b9dfe4.json"
-  - "configs/application/config.php"
 
 static_directories:
   - "htdocs/templates/forumphp2016/images/intervenants"


### PR DESCRIPTION
suite à https://github.com/afup/web/pull/1421

on évite cette erreur quand on tente de créer un lien symbloque vers un fichier inexistant :
```
failed: [localhost] (item=configs/application/config.php) => {"failed": true, "item": "configs/application/config.php", "msg": "Error while linking: [Errno 2] Aucun fichier ou dossier de ce type", "path": "/home/sources/web/releases/20240213220204/configs/application/config.php", "state": "absent"}
```

//cc @stakovicz 