### PR TITLE
on lance bien le composer install avec php 7.0

### DIFF
--- a/playbooks/web/tasks.yml
+++ b/playbooks/web/tasks.yml
@@ -57,7 +57,7 @@
     COMPOSER_HOME: "/tmp/tmp_composer_home_deploy"
 
 - name: "Installing composer dependencies"
-  shell: "php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction --working-dir={{ item }}"
+  shell: "php7.0 composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction --working-dir={{ item }}"
   environment:
     COMPOSER_HOME: "/tmp/tmp_composer_home_deploy"
     SYMFONY_ENV: prod

--- a/playbooks/web/tasks.yml
+++ b/playbooks/web/tasks.yml
@@ -104,7 +104,7 @@
     - "var/logs"
 
 - name: "Running SQL patches"
-  shell: "php ./bin/phinx migrate"
+  shell: "php7.0 ./bin/phinx migrate"
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
 


### PR DESCRIPTION
Cela est lié à https://github.com/afup/web/pull/1452

suite au passage à PHP 7.0 on passage aussi par php7.0 pour lancer composer.